### PR TITLE
Add caching for city response data with fallback on failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /prototypes/
+/cached_data/
 
 .python-version
 __pycache__

--- a/src/city_data_cache.py
+++ b/src/city_data_cache.py
@@ -2,6 +2,16 @@ import json
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from pydantic import BaseModel
+
+from src.city_data_builder.model import ResponseGraphNode, ResponseTramTrip
+
+
+class ResponseCityData(BaseModel):
+    tram_track_graph: list[ResponseGraphNode]
+    tram_trips: list[ResponseTramTrip]
+    last_updated: str = datetime.now().isoformat()
+
 
 class CityDataCache:
     def __init__(
@@ -22,25 +32,29 @@ class CityDataCache:
             return False
         return datetime.now() - datetime.fromtimestamp(path.stat().st_mtime) < self.ttl
 
-    def load_cached_data(self, city_id: str) -> dict:
+    def load_cached_data(self, city_id: str) -> ResponseCityData:
         with open(self._get_path_to_cache(city_id), "r", encoding="utf-8") as f:
             data = json.load(f)
-        data["last_updated"] = self._get_last_modified_timestamp(city_id)
-        return data
+        return ResponseCityData(**data)
 
-    def save_to_cache(self, city_id: str, data: dict):
+    def store_and_return(
+        self,
+        city_id: str,
+        tram_track_graph: list[ResponseGraphNode],
+        tram_trips: list[ResponseTramTrip],
+    ) -> ResponseCityData:
         def default(obj):
             if hasattr(obj, "model_dump"):
                 return obj.model_dump(mode="json")
             raise TypeError(f"{type(obj).__name__} is not JSON serializable")
 
+        data = ResponseCityData(
+            tram_track_graph=tram_track_graph,
+            tram_trips=tram_trips,
+            last_updated=datetime.now().isoformat(),
+        )
+
         with open(self._get_path_to_cache(city_id), "w", encoding="utf-8") as f:
             json.dump(data, f, default=default)
 
-    def _get_last_modified_timestamp(self, city_id: str) -> str | None:
-        path = self._get_path_to_cache(city_id)
-        return (
-            datetime.fromtimestamp(path.stat().st_mtime).isoformat()
-            if path.exists()
-            else None
-        )
+        return data

--- a/src/city_data_cache.py
+++ b/src/city_data_cache.py
@@ -3,11 +3,15 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
-from src.city_data_builder.model import ResponseGraphNode, ResponseTramTrip
+from src.city_data_builder.model import (
+    ResponseGraphNode,
+    ResponseGraphTramStop,
+    ResponseTramTrip,
+)
 
 
 class ResponseCityData(BaseModel):
-    tram_track_graph: list[ResponseGraphNode]
+    tram_track_graph: list[ResponseGraphNode | ResponseGraphTramStop]
     tram_trips: list[ResponseTramTrip]
     last_updated: datetime = Field(default_factory=lambda: datetime.now())
 

--- a/src/city_data_cache.py
+++ b/src/city_data_cache.py
@@ -1,8 +1,7 @@
-import json
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from src.city_data_builder.model import ResponseGraphNode, ResponseTramTrip
 
@@ -10,7 +9,7 @@ from src.city_data_builder.model import ResponseGraphNode, ResponseTramTrip
 class ResponseCityData(BaseModel):
     tram_track_graph: list[ResponseGraphNode]
     tram_trips: list[ResponseTramTrip]
-    last_updated: str = datetime.now().isoformat()
+    last_updated: datetime = Field(default_factory=lambda: datetime.now())
 
 
 class CityDataCache:
@@ -21,21 +20,26 @@ class CityDataCache:
     ):
         self.cache_dir = cache_dir
         self.ttl = timedelta(hours=ttl_hours)
+
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     def _get_path_to_cache(self, city_id: str) -> Path:
         return self.cache_dir / f"{city_id}.json"
 
     def is_cache_fresh(self, city_id: str) -> bool:
-        path = self._get_path_to_cache(city_id)
-        if not path.exists():
+        if not (path := self._get_path_to_cache(city_id)).exists():
             return False
-        return datetime.now() - datetime.fromtimestamp(path.stat().st_mtime) < self.ttl
+
+        timedelta_since_last_update = datetime.now() - datetime.fromtimestamp(
+            path.stat().st_mtime
+        )
+
+        return timedelta_since_last_update < self.ttl
 
     def load_cached_data(self, city_id: str) -> ResponseCityData:
-        with open(self._get_path_to_cache(city_id), "r", encoding="utf-8") as f:
-            data = json.load(f)
-        return ResponseCityData(**data)
+        return ResponseCityData.model_validate_json(
+            self._get_path_to_cache(city_id).read_text()
+        )
 
     def store_and_return(
         self,
@@ -43,18 +47,11 @@ class CityDataCache:
         tram_track_graph: list[ResponseGraphNode],
         tram_trips: list[ResponseTramTrip],
     ) -> ResponseCityData:
-        def default(obj):
-            if hasattr(obj, "model_dump"):
-                return obj.model_dump(mode="json")
-            raise TypeError(f"{type(obj).__name__} is not JSON serializable")
-
         data = ResponseCityData(
             tram_track_graph=tram_track_graph,
             tram_trips=tram_trips,
-            last_updated=datetime.now().isoformat(),
         )
 
-        with open(self._get_path_to_cache(city_id), "w", encoding="utf-8") as f:
-            json.dump(data, f, default=default)
+        self._get_path_to_cache(city_id).write_text(data.model_dump_json())
 
         return data

--- a/src/city_data_cache.py
+++ b/src/city_data_cache.py
@@ -13,30 +13,32 @@ class CityDataCache:
         self.ttl = timedelta(hours=ttl_hours)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-    def _get_path(self, city_id: str) -> Path:
+    def _get_path_to_cache(self, city_id: str) -> Path:
         return self.cache_dir / f"{city_id}.json"
 
-    def is_valid(self, city_id: str) -> bool:
-        path = self._get_path(city_id)
+    def is_cache_fresh(self, city_id: str) -> bool:
+        path = self._get_path_to_cache(city_id)
         if not path.exists():
             return False
         return datetime.now() - datetime.fromtimestamp(path.stat().st_mtime) < self.ttl
 
-    def load(self, city_id: str) -> dict:
-        with open(self._get_path(city_id), "r", encoding="utf-8") as f:
-            return json.load(f)
+    def load_cached_data(self, city_id: str) -> dict:
+        with open(self._get_path_to_cache(city_id), "r", encoding="utf-8") as f:
+            data = json.load(f)
+        data["last_updated"] = self._get_last_modified_timestamp(city_id)
+        return data
 
-    def save(self, city_id: str, data: dict):
+    def save_to_cache(self, city_id: str, data: dict):
         def default(obj):
             if hasattr(obj, "model_dump"):
                 return obj.model_dump(mode="json")
             raise TypeError(f"{type(obj).__name__} is not JSON serializable")
 
-        with open(self._get_path(city_id), "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=4, default=default)
+        with open(self._get_path_to_cache(city_id), "w", encoding="utf-8") as f:
+            json.dump(data, f, default=default)
 
-    def last_updated(self, city_id: str) -> str | None:
-        path = self._get_path(city_id)
+    def _get_last_modified_timestamp(self, city_id: str) -> str | None:
+        path = self._get_path_to_cache(city_id)
         return (
             datetime.fromtimestamp(path.stat().st_mtime).isoformat()
             if path.exists()

--- a/src/city_data_cache.py
+++ b/src/city_data_cache.py
@@ -1,0 +1,44 @@
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+class CityDataCache:
+    def __init__(
+        self,
+        cache_dir: Path = Path(__file__).parents[1] / "cached_data",
+        ttl_hours: int = 24,
+    ):
+        self.cache_dir = cache_dir
+        self.ttl = timedelta(hours=ttl_hours)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _get_path(self, city_id: str) -> Path:
+        return self.cache_dir / f"{city_id}.json"
+
+    def is_valid(self, city_id: str) -> bool:
+        path = self._get_path(city_id)
+        if not path.exists():
+            return False
+        return datetime.now() - datetime.fromtimestamp(path.stat().st_mtime) < self.ttl
+
+    def load(self, city_id: str) -> dict:
+        with open(self._get_path(city_id), "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def save(self, city_id: str, data: dict):
+        def default(obj):
+            if hasattr(obj, "model_dump"):
+                return obj.model_dump(mode="json")
+            raise TypeError(f"{type(obj).__name__} is not JSON serializable")
+
+        with open(self._get_path(city_id), "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=4, default=default)
+
+    def last_updated(self, city_id: str) -> str | None:
+        path = self._get_path(city_id)
+        return (
+            datetime.fromtimestamp(path.stat().st_mtime).isoformat()
+            if path.exists()
+            else None
+        )

--- a/src/server.py
+++ b/src/server.py
@@ -21,7 +21,7 @@ cache = CityDataCache()
 
 
 @app.get("/cities")
-def cities():
+def cities() -> dict[str, CityConfiguration]:
     city_configuration_by_id: dict[str, CityConfiguration] = {}
 
     for file in filter(lambda x: x.is_file(), CONFIG_DIRECTORY_PATH.iterdir()):
@@ -36,7 +36,7 @@ def cities():
     return city_configuration_by_id
 
 
-@app.get("/cities/{city_id}", response_model=ResponseCityData)
+@app.get("/cities/{city_id}")
 def get_city_data(city_id: str) -> ResponseCityData:
     if not (file_path := CONFIG_DIRECTORY_PATH / f"{city_id}.json").is_file():
         raise HTTPException(404, "City not found")
@@ -62,7 +62,7 @@ def get_city_data(city_id: str) -> ResponseCityData:
         except Exception as inner:
             logger.exception(f"Cache loading failed for {city_id}", exc_info=inner)
 
-        raise HTTPException(422, "Data processing for {city_id} failed.")
+        raise HTTPException(422, f"Data processing for {city_id} failed.")
 
 
 if __name__ == "__main__":

--- a/tests/test_city_cache_data.py
+++ b/tests/test_city_cache_data.py
@@ -1,6 +1,5 @@
-import os
 import tempfile
-from datetime import datetime, timedelta
+import time
 from pathlib import Path
 
 import pytest
@@ -38,7 +37,9 @@ class TestCityDataCache:
         # Assert
         assert not is_fresh
 
-    def test_store_and_load_data(self, sample_data):
+    def test_store_and_load_data(
+        self, sample_data: tuple[list[ResponseGraphNode], list[ResponseTramTrip]]
+    ):
         # Arrange
         cache_dir = Path(tempfile.mkdtemp())
         cache = CityDataCache(cache_dir=cache_dir, ttl_hours=1)
@@ -54,7 +55,9 @@ class TestCityDataCache:
         assert stored_data == loaded_data
         assert cache.is_cache_fresh(city_id)
 
-    def test_is_cache_fresh_expired(self, sample_data):
+    def test_is_cache_fresh_expired(
+        self, sample_data: tuple[list[ResponseGraphNode], list[ResponseTramTrip]]
+    ):
         # Arrange
         cache_dir = Path(tempfile.mkdtemp())
         cache = CityDataCache(cache_dir=cache_dir, ttl_hours=0)
@@ -62,9 +65,8 @@ class TestCityDataCache:
         tram_track_graph, tram_trips = sample_data
         cache.store_and_return(city_id, tram_track_graph, tram_trips)
 
-        old_time = datetime.now() - timedelta(hours=1)
-        path = cache._get_path_to_cache(city_id)
-        os.utime(path, (old_time.timestamp(), old_time.timestamp()))
+        # Sleeping so we're sure the cache expires
+        time.sleep(1)
 
         # Act
         is_fresh = cache.is_cache_fresh(city_id)

--- a/tests/test_city_cache_data.py
+++ b/tests/test_city_cache_data.py
@@ -1,0 +1,61 @@
+import os
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from src.city_data_builder.model import (
+    ResponseGraphEdge,
+    ResponseGraphNode,
+    ResponseTramTrip,
+)
+from src.city_data_cache import CityDataCache, ResponseCityData
+
+
+class TestCityDataCache:
+    @pytest.fixture
+    def temp_cache(self):
+        cache_dir = Path(tempfile.mkdtemp())
+        return CityDataCache(cache_dir=cache_dir, ttl_hours=1)
+
+    @staticmethod
+    def sample_data():
+        tram_track_graph = [
+            ResponseGraphNode(
+                id=1,
+                lat=50.0,
+                lon=19.0,
+                neighbors=[ResponseGraphEdge(id=2, length=100.0, azimuth=90.0)],
+            )
+        ]
+        tram_trips = [ResponseTramTrip(route="1", trip_head_sign="Centrum", stops=[])]
+        return tram_track_graph, tram_trips
+
+    def test_cache_miss_if_no_file(self, temp_cache: CityDataCache):
+        assert not temp_cache.is_cache_fresh("unknown_city")
+
+    def test_store_and_load_data(self, temp_cache: CityDataCache):
+        city_id = "sample_city"
+        tram_track_graph, tram_trips = self.sample_data()
+
+        stored_data = temp_cache.store_and_return(city_id, tram_track_graph, tram_trips)
+        loaded_data = temp_cache.load_cached_data(city_id)
+
+        assert isinstance(loaded_data, ResponseCityData)
+        assert stored_data == loaded_data
+        assert temp_cache.is_cache_fresh(city_id)
+
+    def test_cache_expiry(self):
+        cache_dir = Path(tempfile.mkdtemp())
+        short_lived_cache = CityDataCache(cache_dir=cache_dir, ttl_hours=0)
+        city_id = "old_city"
+        tram_track_graph, tram_trips = self.sample_data()
+
+        short_lived_cache.store_and_return(city_id, tram_track_graph, tram_trips)
+
+        old_time = datetime.now() - timedelta(hours=1)
+        path = short_lived_cache._get_path_to_cache(city_id)
+        os.utime(path, (old_time.timestamp(), old_time.timestamp()))
+
+        assert not short_lived_cache.is_cache_fresh(city_id)

--- a/tests/test_city_cache_data.py
+++ b/tests/test_city_cache_data.py
@@ -15,12 +15,7 @@ from src.city_data_cache import CityDataCache, ResponseCityData
 
 class TestCityDataCache:
     @pytest.fixture
-    def temp_cache(self):
-        cache_dir = Path(tempfile.mkdtemp())
-        return CityDataCache(cache_dir=cache_dir, ttl_hours=1)
-
-    @staticmethod
-    def sample_data():
+    def sample_data(self):
         tram_track_graph = [
             ResponseGraphNode(
                 id=1,
@@ -32,30 +27,47 @@ class TestCityDataCache:
         tram_trips = [ResponseTramTrip(route="1", trip_head_sign="Centrum", stops=[])]
         return tram_track_graph, tram_trips
 
-    def test_cache_miss_if_no_file(self, temp_cache: CityDataCache):
-        assert not temp_cache.is_cache_fresh("unknown_city")
+    def test_is_cache_fresh_no_file(self):
+        # Arrange
+        cache_dir = Path(tempfile.mkdtemp())
+        cache = CityDataCache(cache_dir=cache_dir, ttl_hours=1)
 
-    def test_store_and_load_data(self, temp_cache: CityDataCache):
+        # Act
+        is_fresh = cache.is_cache_fresh("unknown_city")
+
+        # Assert
+        assert not is_fresh
+
+    def test_store_and_load_data(self, sample_data):
+        # Arrange
+        cache_dir = Path(tempfile.mkdtemp())
+        cache = CityDataCache(cache_dir=cache_dir, ttl_hours=1)
         city_id = "sample_city"
-        tram_track_graph, tram_trips = self.sample_data()
+        tram_track_graph, tram_trips = sample_data
 
-        stored_data = temp_cache.store_and_return(city_id, tram_track_graph, tram_trips)
-        loaded_data = temp_cache.load_cached_data(city_id)
+        # Act
+        stored_data = cache.store_and_return(city_id, tram_track_graph, tram_trips)
+        loaded_data = cache.load_cached_data(city_id)
 
+        # Assert
         assert isinstance(loaded_data, ResponseCityData)
         assert stored_data == loaded_data
-        assert temp_cache.is_cache_fresh(city_id)
+        assert cache.is_cache_fresh(city_id)
 
-    def test_cache_expiry(self):
+    def test_is_cache_fresh_expired(self, sample_data):
+        # Arrange
         cache_dir = Path(tempfile.mkdtemp())
-        short_lived_cache = CityDataCache(cache_dir=cache_dir, ttl_hours=0)
+        cache = CityDataCache(cache_dir=cache_dir, ttl_hours=0)
         city_id = "old_city"
-        tram_track_graph, tram_trips = self.sample_data()
-
-        short_lived_cache.store_and_return(city_id, tram_track_graph, tram_trips)
+        tram_track_graph, tram_trips = sample_data
+        cache.store_and_return(city_id, tram_track_graph, tram_trips)
 
         old_time = datetime.now() - timedelta(hours=1)
-        path = short_lived_cache._get_path_to_cache(city_id)
+        path = cache._get_path_to_cache(city_id)
         os.utime(path, (old_time.timestamp(), old_time.timestamp()))
 
-        assert not short_lived_cache.is_cache_fresh(city_id)
+        # Act
+        is_fresh = cache.is_cache_fresh(city_id)
+
+        # Assert
+        assert not is_fresh

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -77,8 +77,10 @@ class TestServer:
     @patch("src.tram_stop_mapper.gtfs_package.GTFSPackage.from_url")
     @patch("src.overpass_client.OverpassClient.get_tram_stops_and_tracks")
     @patch("src.overpass_client.OverpassClient.get_relations_and_stops")
+    @patch("src.city_data_cache.CityDataCache.is_cache_fresh", return_value=False)
     def test_get_city_data(
         self,
+        is_cache_fresh_mock: MagicMock,
         get_relations_and_stops_mock: MagicMock,
         get_tram_stops_and_tracks_mock: MagicMock,
         gtfs_package_from_url_mock: MagicMock,
@@ -138,6 +140,11 @@ class TestServer:
                 gtfs_stop_ids = tram_track_node["gtfs_stop_ids"]
                 assert isinstance(gtfs_stop_ids, list)
                 assert all(isinstance(item, str) for item in gtfs_stop_ids)
+
+        assert any(
+            ("name" in tram_track_node or "gtfs_stop_ids" in tram_track_node)
+            for tram_track_node in tram_track_graph
+        )
 
         tram_trips = city_data["tram_trips"]
         assert tram_trips

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,7 @@ import overpy
 import pytest
 from fastapi.testclient import TestClient
 
+from src.city_data_cache import CityDataCache
 from src.server import app
 from src.tram_stop_mapper import GTFSPackage
 
@@ -171,3 +172,35 @@ class TestServer:
         # Assert
         assert response.status_code == 404
         assert response.json()["detail"] == "City not found"
+
+    @patch("src.server.cache")
+    @patch("src.server.CityDataBuilder.__init__", return_value=None)
+    @patch("src.server.CityDataBuilder.tram_track_graph_data", new_callable=MagicMock)
+    @patch("src.server.CityDataBuilder.tram_trips_data", new_callable=MagicMock)
+    def test_cache_used_after_initial_build(
+        self, tram_trips_mock, tram_track_mock, builder_init_mock, cache_mock, tmp_path
+    ):
+
+        city_id = "krakow"
+
+        temp_cache = CityDataCache(cache_dir=tmp_path)
+        cache_mock._get_path_to_cache.side_effect = temp_cache._get_path_to_cache
+        cache_mock.is_cache_fresh.side_effect = temp_cache.is_cache_fresh
+        cache_mock.load_cached_data.side_effect = temp_cache.load_cached_data
+        cache_mock.store_and_return.side_effect = temp_cache.store_and_return
+
+        tram_trips_mock.return_value = []
+        tram_track_mock.return_value = []
+
+        response1 = self.client.get(f"/cities/{city_id}")
+        assert response1.status_code == 200
+        assert builder_init_mock.called
+        assert temp_cache._get_path_to_cache(city_id).exists()
+
+        builder_init_mock.reset_mock()
+
+        response2 = self.client.get(f"/cities/{city_id}")
+        assert response2.status_code == 200
+        assert "last_updated" in response1.json()
+        assert response1.json() == response2.json()
+        builder_init_mock.assert_not_called()


### PR DESCRIPTION
### Related issues
- #33

### Short description
Added caching mechanism for the `/cities/{city_id}` endpoint to improve response time.
Introduced the `CityDataCache` class for managing cache storage.