### PR TITLE
Redor144/add max speed property to edges

### DIFF
--- a/src/city_data_builder/city_data_builder.py
+++ b/src/city_data_builder/city_data_builder.py
@@ -79,7 +79,10 @@ class CityDataBuilder:
         for source, dest, data in self._tram_track_graph.edges.data():
             response_data_edge_by_source[source].append(
                 ResponseGraphEdge(
-                    id=dest.id, length=data["length"], azimuth=data["azimuth"]
+                    id=dest.id,
+                    length=data["length"],
+                    azimuth=data["azimuth"],
+                    max_speed=data["max_speed"],
                 )
             )
 

--- a/src/city_data_builder/model.py
+++ b/src/city_data_builder/model.py
@@ -7,6 +7,7 @@ class ResponseGraphEdge(BaseModel):
     id: int
     length: float
     azimuth: float
+    max_speed: float
 
 
 class ResponseGraphNode(BaseModel):

--- a/src/overpass_client/overpass_client.py
+++ b/src/overpass_client/overpass_client.py
@@ -5,7 +5,7 @@ class OverpassClient:
     _OVERPASS = overpy.Overpass()
 
     _RELATIONS_STOPS_QUERY_TEMPLATE = """
-    [out:json];
+    [out:json][timeout:600];
     area["name"="{area_name}"]->.search_area;
     (
         relation["route"="tram"](area.search_area);
@@ -15,7 +15,7 @@ class OverpassClient:
     """
 
     _RELATIONS_STOPS_NODES_QUERY_TEMPLATE = """
-    [out:json];
+    [out:json][timeout:600];
     area["name"="{area_name}"]->.search_area;
     (
         relation["route"="tram"](area.search_area);
@@ -26,7 +26,7 @@ class OverpassClient:
     """
 
     _TRAM_STOPS_AND_TRACKS_TEMPLATE = """
-    [out:json];
+    [out:json][timeout:600];
     area["name"="{area_name}"]->.search_area;
     (
         way["railway"="tram"](area.search_area);

--- a/src/tram_track_graph_transformer/tram_track_graph_transformer.py
+++ b/src/tram_track_graph_transformer/tram_track_graph_transformer.py
@@ -3,7 +3,7 @@ import math
 import networkx as nx
 import overpy
 from pyproj import Geod, Transformer
-from shapely.geometry import LineString
+from shapely.geometry import LineString, Point
 
 from src.city_data_builder import CityConfiguration
 from src.tram_track_graph_transformer.exceptions import (
@@ -62,20 +62,31 @@ class TramTrackGraphTransformer:
     def permament_nodes(self) -> set[Node]:
         return self._permanent_nodes.copy()
 
+    @staticmethod
+    def _get_max_speed_for_way(
+        way: overpy.Way, ratio: float = 3.6, default_speed: float = 50.0
+    ) -> float:
+        try:
+            max_speed = float(way.tags.get("maxspeed"))
+        except (ValueError, TypeError):
+            max_speed = default_speed
+        return max_speed / ratio
+
     def _build_tram_track_graph_from_osm_ways(self):
         graph = nx.DiGraph()
 
         for way in self._ways:
             node_ids = [self._nodes_by_id[node.id] for node in way.get_nodes()]
             is_oneway = way.tags.get("oneway") == "yes"
+            max_speed = self._get_max_speed_for_way(way)
 
             for i in range(len(node_ids) - 1):
                 source_node = node_ids[i]
                 destination_node = node_ids[i + 1]
 
-                graph.add_edge(source_node, destination_node)
+                graph.add_edge(source_node, destination_node, max_speed=max_speed)
                 if not is_oneway:
-                    graph.add_edge(destination_node, source_node)
+                    graph.add_edge(destination_node, source_node, max_speed=max_speed)
 
         return graph
 
@@ -139,18 +150,19 @@ class TramTrackGraphTransformer:
 
     def _find_path_between_permanent_nodes(
         self, permanent_node: Node, successor: Node
-    ) -> list[Node]:
+    ) -> list[tuple[Node, float]]:
         """
         Finds the first different permanent node reachable from provided
         `permanent_node` via provided `successor` without backtracking.
         """
 
-        path_coordinates = [permanent_node]
+        path_coords_with_speed = [(permanent_node, 0.0)]
         previous_node, current_node = permanent_node, successor
-
+        current_speed = self._tram_track_graph.get_edge_data(
+            previous_node, current_node
+        )["max_speed"]
         while current_node not in self._permanent_nodes:
-            path_coordinates.append(current_node)
-
+            path_coords_with_speed.append((current_node, current_speed))
             next_candidate = next(
                 filter(
                     lambda x: x != previous_node,
@@ -161,24 +173,28 @@ class TramTrackGraphTransformer:
 
             if next_candidate is None:
                 raise TrackDirectionChangeError(permanent_node.id, current_node.id)
-
+            current_speed = self._tram_track_graph.get_edge_data(
+                current_node, next_candidate
+            )["max_speed"]
             previous_node, current_node = current_node, next_candidate
 
-        path_coordinates.append(current_node)
-
-        return path_coordinates
+        path_coords_with_speed.append((current_node, current_speed))
+        return path_coords_with_speed
 
     @classmethod
     def _interpolate_path_nodes(
-        cls, path_nodes: list[Node], max_distance_in_meters: float
-    ) -> list[tuple[float, float]]:
+        cls, path_nodes: list[tuple[Node, float]], max_distance_in_meters: float
+    ) -> list[tuple[tuple[float, float], float]]:
         meter_coords = [
-            cls._transformer.transform(node.lon, node.lat) for node in path_nodes
+            cls._transformer.transform(node.lon, node.lat) for node, _ in path_nodes
         ]
         line = LineString(meter_coords)
 
         if line.length <= max_distance_in_meters:
-            return [path_nodes[0].coordinates, path_nodes[-1].coordinates]
+            return [
+                (path_nodes[0][0].coordinates, path_nodes[0][1]),
+                (path_nodes[-1][0].coordinates, path_nodes[-1][1]),
+            ]
 
         segment_count = math.ceil(line.length / max_distance_in_meters)
         segment_size = line.length / segment_count
@@ -187,42 +203,61 @@ class TramTrackGraphTransformer:
             line.interpolate(i * segment_size) for i in range(1, segment_count)
         ]
 
-        interpolated_lat_lon = [
-            cls._inverse_transformer.transform(p.x, p.y)[::-1]
-            for p in interpolated_points
+        interpolated_path_with_speed: list[tuple[tuple[float, float], float]] = [
+            (path_nodes[0][0].coordinates, path_nodes[0][1])
         ]
+        cumulative_distance = [0.0]
+        for i in range(1, len(meter_coords)):
+            prev = Point(meter_coords[i - 1])
+            curr = Point(meter_coords[i])
+            cumulative_distance.append(cumulative_distance[-1] + prev.distance(curr))
 
-        return [
-            path_nodes[0].coordinates,
-            *interpolated_lat_lon,
-            path_nodes[-1].coordinates,
-        ]
+        segment_index = 0
+        for p in interpolated_points:
+            distance_to_p = line.project(p)
+            while (
+                segment_index < len(cumulative_distance) - 2
+            ) and cumulative_distance[segment_index + 1] < distance_to_p:
+                segment_index += 1
+
+            speed = path_nodes[segment_index + 1][1]
+            lat_lon = cls._inverse_transformer.transform(p.x, p.y)[::-1]
+            interpolated_path_with_speed.append((lat_lon, speed))
+
+        interpolated_path_with_speed.append(
+            (path_nodes[-1][0].coordinates, path_nodes[-1][1])
+        )
+        return interpolated_path_with_speed
 
     def _get_new_node_id(self):
         self._max_node_id += 1
         return self._max_node_id
 
     @classmethod
-    def _add_geodetic_edge(cls, graph: nx.DiGraph, source_node: Node, dest_node: Node):
+    def _add_geodetic_edge(
+        cls, graph: nx.DiGraph, source_node: Node, dest_node: Node, max_speed: float
+    ):
         azimuth, _, length = cls._geod.inv(
             source_node.lon,
             source_node.lat,
             dest_node.lon,
             dest_node.lat,
         )
-        graph.add_edge(source_node, dest_node, azimuth=azimuth, length=length)
+        graph.add_edge(
+            source_node, dest_node, azimuth=azimuth, length=length, max_speed=max_speed
+        )
 
     def _add_interpolated_nodes_path(
         self,
         densified_graph: nx.DiGraph,
-        interpolated_node_coordinates: list[tuple[float, float]],
+        interpolated_node_coords_with_speed: list[tuple[tuple[float, float], float]],
         nodes_by_coordinates: dict[tuple[float, float], Node],
         first_node: Node,
         last_node: Node,
     ):
         previous_graph_node = first_node
 
-        for lat, lon in interpolated_node_coordinates[1:-1]:
+        for (lat, lon), max_speed in interpolated_node_coords_with_speed[1:-1]:
             if (lat, lon) in nodes_by_coordinates:
                 new_node = nodes_by_coordinates[(lat, lon)]
             else:
@@ -234,14 +269,18 @@ class TramTrackGraphTransformer:
                 )
                 nodes_by_coordinates[(lat, lon)] = new_node
 
-            self._add_geodetic_edge(densified_graph, previous_graph_node, new_node)
+            self._add_geodetic_edge(
+                densified_graph, previous_graph_node, new_node, max_speed
+            )
             previous_graph_node = new_node
 
-        lat, lon = interpolated_node_coordinates[-1]
+        (lat, lon), max_speed = interpolated_node_coords_with_speed[-1]
         if (lat, lon) in nodes_by_coordinates:
             last_node = nodes_by_coordinates[(lat, lon)]
 
-        self._add_geodetic_edge(densified_graph, previous_graph_node, last_node)
+        self._add_geodetic_edge(
+            densified_graph, previous_graph_node, last_node, max_speed
+        )
 
     def densify_graph_by_max_distance(
         self, max_distance_in_meters: float
@@ -270,19 +309,17 @@ class TramTrackGraphTransformer:
                     errors.append(e)
                     continue
 
-                interpolated_node_coordinates = self._interpolate_path_nodes(
+                interpolated_node_coords_with_speed = self._interpolate_path_nodes(
                     path_nodes, max_distance_in_meters
                 )
-
                 self._add_interpolated_nodes_path(
                     densified_graph,
-                    interpolated_node_coordinates,
+                    interpolated_node_coords_with_speed,
                     nodes_by_coordinates,
                     permanent_node,
-                    path_nodes[-1],
+                    path_nodes[-1][0],
                 )
 
         if errors:
             raise ExceptionGroup("Track direction errors during densification", errors)
-
         return densified_graph

--- a/src/tram_track_graph_transformer/tram_track_graph_transformer.py
+++ b/src/tram_track_graph_transformer/tram_track_graph_transformer.py
@@ -1,4 +1,5 @@
 import math
+from itertools import chain
 
 import networkx as nx
 import overpy
@@ -69,7 +70,7 @@ class TramTrackGraphTransformer:
     ) -> float:
         try:
             max_speed = float(way.tags.get("maxspeed"))
-        except (ValueError, TypeError):
+        except TypeError:
             max_speed = default_speed_kph
         return max_speed / cls._KPH_TO_MS
 
@@ -149,8 +150,10 @@ class TramTrackGraphTransformer:
         for node in self._tram_track_graph.nodes:
             speeds = {
                 data.get("max_speed")
-                for _, _, data in list(self._tram_track_graph.in_edges(node, data=True))
-                + list(self._tram_track_graph.out_edges(node, data=True))
+                for _, _, data in chain(
+                    self._tram_track_graph.in_edges(node, data=True),
+                    self._tram_track_graph.out_edges(node, data=True),
+                )
             }
             if len(speeds) > 1:
                 result.add(node)

--- a/tests/city_data_builder/test_city_configuration.py
+++ b/tests/city_data_builder/test_city_configuration.py
@@ -65,10 +65,14 @@ class TestCityConfiguration:
 
     def test_from_path_invalid_json(self, caplog: LogCaptureFixture):
         # Arrange
-        with tempfile.NamedTemporaryFile() as temp_file:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            delete=False,
+            dir=Path.cwd(),
+        ) as temp_file:
             temp_file.write(b"{Malformed json")
-            path = Path.cwd() / temp_file.name
-
+            path = Path(temp_file.name)
+        try:
             # Act
             with pytest.raises(ValidationError) as exc_info, caplog.at_level(
                 logging.ERROR, "src.city_data_builder.city_configuration"
@@ -78,6 +82,8 @@ class TestCityConfiguration:
             # Assert
             assert "Invalid JSON" in str(exc_info.value)
             assert f"Invalid configuration file: {path}" in caplog.text
+        finally:
+            path.unlink(missing_ok=True)
 
     @patch.object(CityConfiguration, "CITIES_DIRECTORY_PATH", new_callable=PropertyMock)
     def test_get_all(

--- a/tests/city_data_builder/test_city_data_builder.py
+++ b/tests/city_data_builder/test_city_data_builder.py
@@ -46,7 +46,7 @@ class TestCityDataBuilder:
         )
         gtfs_package_from_url_mock.return_value = gtfs_package
 
-        expected_node_count, expected_edge_count = 43227, 45953
+        expected_node_count, expected_edge_count = 43321, 46047
 
         # Act
         city_data_builder = CityDataBuilder(

--- a/tests/overpass_client/test_overpass_client.py
+++ b/tests/overpass_client/test_overpass_client.py
@@ -11,7 +11,7 @@ class TestOverpassClient:
     CUSTOM_NODE_IDS = [1, 2, 3, 4]
 
     EXPECTED_RELATIONS_AND_STOPS_QUERY = """
-    [out:json];
+    [out:json][timeout:600];
     area["name"="Some area"]->.search_area;
     (
         relation["route"="tram"](area.search_area);
@@ -28,7 +28,7 @@ class TestOverpassClient:
                 "Some area",
                 [1, 2, 3, 4],
                 """
-                [out:json];
+                [out:json][timeout:600];
                 area["name"="Some area"]->.search_area;
                 (
                     relation["route"="tram"](area.search_area);
@@ -43,7 +43,7 @@ class TestOverpassClient:
                 "Some area",
                 [],
                 """
-                [out:json];
+                [out:json][timeout:600];
                 area["name"="Some area"]->.search_area;
                 (
                     relation["route"="tram"](area.search_area);

--- a/tests/test_city_cache_data.py
+++ b/tests/test_city_cache_data.py
@@ -27,7 +27,9 @@ class TestCityDataCache:
                 id=1,
                 lat=50.0,
                 lon=19.0,
-                neighbors=[ResponseGraphEdge(id=2, length=100.0, azimuth=90.0)],
+                neighbors=[
+                    ResponseGraphEdge(id=2, length=100.0, azimuth=90.0, max_speed=5)
+                ],
             )
         ]
 


### PR DESCRIPTION
### Related issues
- #20

### Short description
Now the edges in `_tram_track_graph` contain the `max_speed` attribute. The most significant changes were made in `_interpolate_path_nodes`, where we now calculate the cumulative distance from the start to the end of the interpolated line. For each point, we identify the segment from the original graph it belongs to and assign the speed from the node at the end of that segment.